### PR TITLE
add user-agent to requests.get

### DIFF
--- a/aoc_to_markdown.py
+++ b/aoc_to_markdown.py
@@ -16,7 +16,10 @@ def get_url(year, day):
 
 
 def get_response(url):
-    response = requests.get(url, cookies={'session': os.getenv('SESSION_ID')})
+    response = requests.get(url,
+        headers={'User-Agent': 'github.com/antonio-ramadas/aoc-to-markdown by antonio_ramadas@hotmail.com'},
+        cookies={'session': os.getenv('SESSION_ID')}
+    )
 
     if response.status_code != 200:
         raise ValueError(f"Querying the url {url} resulted in status code {response.status_code} with the following "

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-beautifulsoup4==4.8.1
+beautifulsoup4==4.11.1
 requests==2.22.0


### PR DESCRIPTION
The AdventOfCode organizer has posted on reddit, asking to include a different User-Agent on automated requests:
https://www.reddit.com/r/adventofcode/comments/z9dhtd/please_include_your_contact_info_in_the_useragent

ps: i've used the email from the commits. If you do not want it to be explicitly on the code, you may change it to `github.com/antonio-ramadas` or even `9095073+antonio-ramadas@users.noreply.github.com`