### PR TITLE
fix: check 'star' inside tag['class'] List

### DIFF
--- a/aoc_to_markdown.py
+++ b/aoc_to_markdown.py
@@ -50,7 +50,7 @@ def html_tags_to_markdown(tag, is_first_article):
         tag.insert_after('\n')
         tag.unwrap()
     elif tag.name == 'em':
-        style = '**' if tag.has_attr('class') and tag['class'] == 'star' else '*'
+        style = '**' if tag.has_attr('class') and 'star' in tag['class'] else '*'
         tag.insert_before(style)
         tag.insert_after(style)
         tag.unwrap()


### PR DESCRIPTION
tag['class'] is a List, not a string.

Even if it is a string, the code will still be valid 
(well, it will consider 'start' as 'star', but i think it is ok on this context)